### PR TITLE
Add Supabase sync guidance and test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Profit First cash flow forecast dashboard powered by Next.js and Supabase.
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
    ```
 3. Apply the database schema found in [`docs/supabase-schema.sql`](docs/supabase-schema.sql) to your Supabase project. The schema creates the tables and views that the dashboard reads, such as `clients`, `pf_accounts`, allocation targets, and the monthly balance/activity views used throughout the UI.
+4. (Optional) Load the sample fixtures in [`docs/supabase-test-fixtures.sql`](docs/supabase-test-fixtures.sql) to validate the end-to-end Supabase connection with representative data before wiring in your production sources.
+
+See [the Supabase sync checklist](docs/supabase-sync-guide.md) for a step-by-step walkthrough on verifying that the database and every page in the app can exchange data with Supabase.
 4. Start the development server
    ```bash
    npm run dev

--- a/docs/supabase-sync-guide.md
+++ b/docs/supabase-sync-guide.md
@@ -1,0 +1,61 @@
+# Supabase Sync Checklist
+
+Use this guide to confirm that the Profit First Forecast dashboard can read and write data to your Supabase project after applying the latest database updates.
+
+## 1. Configure environment variables
+
+Create an `.env.local` file in the project root with your Supabase credentials:
+
+```
+NEXT_PUBLIC_SUPABASE_URL="https://<your-project>.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="<anon-key>"
+```
+
+Restart the Next.js dev server after saving the file so that the new environment variables are picked up.
+
+## 2. Apply the core schema
+
+Run the SQL in [`docs/supabase-schema.sql`](./supabase-schema.sql) against your Supabase database. The script provisions every table and view referenced in the UI (clients, Profit First accounts, allocation targets, balances, activity views, etc.).
+
+If you make schema changes in Supabase, re-run the script locally to keep the checked-in version in sync.
+
+## 3. Seed sample data (optional but recommended)
+
+Execute [`docs/supabase-test-fixtures.sql`](./supabase-test-fixtures.sql) to insert a representative client, account catalog, allocation targets, balances, and activity so that every page of the dashboard has data to render. This lets you confirm the UI wiring before integrating real production feeds.
+
+## 4. Validate the connection from the app
+
+With the dev server running (`npm run dev`), load the following routes and ensure data is present:
+
+- `/` – Should display the demo client's balances, projections, and charts.
+- `/settings` – Should list the client catalog, allocation targets, rollout plan, and allow saving updates.
+
+If the UI shows a "Supabase is not configured" warning, double-check the environment variables in step 1.
+
+## 5. Spot-check Supabase reads and writes
+
+Use the Supabase SQL editor or `psql` to verify that the tables reflect actions taken in the UI:
+
+- Creating or editing allocations in the **Settings → Allocation Targets** section should upsert rows in `allocation_targets`.
+- Saving rollout plans should write to both `allocation_current` and `allocation_rollout_steps`.
+- Adding custom projections from the drill-down views should insert rows into `pf_custom_projections`.
+
+You can confirm with queries such as:
+
+```sql
+select * from public.allocation_targets order by client_id, effective_date, pf_slug;
+select * from public.allocation_rollout_steps order by client_id, quarter_index, pf_slug;
+select * from public.pf_custom_projections order by created_at desc;
+```
+
+## 6. Automate regression checks
+
+Once your Supabase instance has real data, consider adding nightly jobs or cron triggers that mirror production data into a staging schema. Re-running the fixture script and replaying UI flows against staging ensures that schema changes stay compatible with the app.
+
+## 7. Troubleshooting tips
+
+- Ensure row level security (RLS) policies allow the anon key to read/write the tables touched by the UI. Start by disabling RLS while testing, then add scoped policies.
+- If you change column names or add tables, update the queries in `app/page.tsx` and `app/settings/page.tsx` accordingly.
+- Inspect browser devtools → Network tab to confirm Supabase responses when debugging.
+
+Following these steps ensures the dashboard, the updated main database, and Supabase stay in sync so you can confidently run data tests.

--- a/docs/supabase-test-fixtures.sql
+++ b/docs/supabase-test-fixtures.sql
@@ -1,0 +1,130 @@
+-- Sample data to validate the Profit First Forecast dashboard wiring
+-- Run after executing docs/supabase-schema.sql
+
+with upsert_client as (
+  insert into public.clients (id, name)
+  values ('11111111-1111-4111-8111-111111111111', 'Demo Client Co.')
+  on conflict (id) do update set name = excluded.name
+  returning id
+)
+insert into public.pf_accounts (id, client_id, slug, name, color, sort_order)
+select
+  gen_random_uuid(),
+  uc.id,
+  slug,
+  name,
+  color,
+  row_number() over ()
+from upsert_client uc
+cross join lateral (values
+  ('income', 'Income', '#0EA5E9'),
+  ('profit', 'Profit', '#6366F1'),
+  ('owners_pay', "Owner's Pay", '#22C55E'),
+  ('tax', 'Tax', '#F97316'),
+  ('operating_expenses', 'Operating Expenses', '#A855F7')
+) as accounts(slug, name, color)
+on conflict (client_id, slug) do update set name = excluded.name, color = excluded.color;
+
+-- Allocation targets effective this quarter
+insert into public.allocation_targets (client_id, effective_date, pf_slug, pct)
+select uc.id, date_trunc('quarter', current_date)::date, slug, pct
+from upsert_client uc
+join (values
+  ('income', 1.0),
+  ('profit', 0.1),
+  ('owners_pay', 0.35),
+  ('tax', 0.15),
+  ('operating_expenses', 0.4)
+) as targets(slug, pct) on true
+on conflict (client_id, effective_date, pf_slug) do update set pct = excluded.pct;
+
+-- Baseline allocation percentages
+insert into public.allocation_current (client_id, pf_slug, pct)
+select uc.id, slug, pct
+from upsert_client uc
+join (values
+  ('income', 1.0),
+  ('profit', 0.05),
+  ('owners_pay', 0.3),
+  ('tax', 0.15),
+  ('operating_expenses', 0.5)
+) as current(slug, pct) on true
+on conflict (client_id, pf_slug) do update set pct = excluded.pct;
+
+-- Rollout plan for the next four quarters
+insert into public.allocation_rollout_steps (client_id, quarter_index, pf_slug, pct)
+select uc.id, quarter_index, slug, pct
+from upsert_client uc
+join (values
+  (1, 'profit', 0.06),
+  (1, 'owners_pay', 0.31),
+  (1, 'tax', 0.15),
+  (1, 'operating_expenses', 0.48),
+  (2, 'profit', 0.07),
+  (2, 'owners_pay', 0.32),
+  (2, 'tax', 0.15),
+  (2, 'operating_expenses', 0.46),
+  (3, 'profit', 0.08),
+  (3, 'owners_pay', 0.33),
+  (3, 'tax', 0.15),
+  (3, 'operating_expenses', 0.44),
+  (4, 'profit', 0.09),
+  (4, 'owners_pay', 0.34),
+  (4, 'tax', 0.15),
+  (4, 'operating_expenses', 0.42)
+) as rollout(quarter_index, slug, pct) on true
+on conflict (client_id, quarter_index, pf_slug) do update set pct = excluded.pct;
+
+-- Monthly balances and activity for the last six months
+with months as (
+  select to_char(date_trunc('month', current_date) - (interval '1 month' * g), 'YYYY-MM') as ym
+  from generate_series(0, 5) as g
+)
+insert into public.pf_monthly_balances (client_id, ym, pf_slug, ending_balance)
+select uc.id, m.ym, a.slug,
+  case a.slug
+    when 'income' then 10000 - (row_number() over (partition by a.slug order by m.ym) * 500)
+    when 'profit' then 2500 + (row_number() over (partition by a.slug order by m.ym) * 250)
+    when 'owners_pay' then 4000 + (row_number() over (partition by a.slug order by m.ym) * 150)
+    when 'tax' then 3000 + (row_number() over (partition by a.slug order by m.ym) * 100)
+    else 7000 - (row_number() over (partition by a.slug order by m.ym) * 300)
+  end
+from upsert_client uc
+cross join months m
+join public.pf_accounts a on a.client_id = uc.id
+on conflict (client_id, ym, pf_slug) do update set ending_balance = excluded.ending_balance;
+
+with months as (
+  select to_char(date_trunc('month', current_date) - (interval '1 month' * g), 'YYYY-MM') as ym
+  from generate_series(0, 5) as g
+)
+insert into public.pf_monthly_activity (client_id, ym, pf_slug, net_amount)
+select uc.id, m.ym, a.slug,
+  case a.slug
+    when 'income' then 18000
+    when 'profit' then 1500
+    when "owners_pay" then 6000
+    when 'tax' then 2700
+    else -12000
+  end
+from upsert_client uc
+cross join months m
+join public.pf_accounts a on a.client_id = uc.id
+on conflict (client_id, ym, pf_slug) do update set net_amount = excluded.net_amount;
+
+-- Projected occurrences for drill-down charts
+insert into public.pf_projected_occurrences (id, client_id, month_start, coa_account_id, kind, name, amount)
+select gen_random_uuid(), uc.id, date_trunc('month', current_date) + (interval '1 month' * g),
+  concat('GL-', 100 + g),
+  case when g % 2 = 0 then 'invoice' else 'bill' end,
+  case when g % 2 = 0 then 'Projected Invoice' else 'Projected Expense' end,
+  case when g % 2 = 0 then 7500 else -4200 end
+from upsert_client uc
+cross join generate_series(0, 3) as g
+on conflict do nothing;
+
+-- Custom projections added from the UI
+insert into public.pf_custom_projections (id, client_id, pf_slug, period, granularity, name, amount, direction, frequency, escalation, escalation_value, start_date)
+select gen_random_uuid(), uc.id, 'operating_expenses', '2024-Q4', 'monthly', 'Marketing Push', 1500, 'outflow', 'monthly', 'fixed', null, date_trunc('month', current_date)
+from upsert_client uc
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- add a Supabase sync checklist that walks through configuring env vars, applying schema, and validating reads/writes from the app
- provide optional Supabase fixture data for smoke-testing the dashboard end-to-end
- update the README to point to the new setup guidance and fixtures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15693bb84832c927aeb943db17366