### PR TITLE
Handle missing Supabase config gracefully

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,26 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+let cachedClient: SupabaseClient | null = null;
+let warnedAboutMissingEnv = false;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (cachedClient) return cachedClient;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    if (!warnedAboutMissingEnv) {
+      warnedAboutMissingEnv = true;
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "Supabase environment variables are not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable data access.",
+        );
+      }
+    }
+    return null;
+  }
+
+  cachedClient = createClient(url, anonKey);
+  return cachedClient;
+}


### PR DESCRIPTION
## Summary
- add a cached Supabase client helper that logs a warning instead of throwing when environment variables are missing
- gate importer and dashboard flows behind configuration checks with clear user messaging and defensive guards for Supabase actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e158cde5d8832cb6ae647aad9af070